### PR TITLE
[SCR-683] feat: Change category in manifest

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -8,7 +8,7 @@
   "source": "git@github.com:konnectors/nextcloud.git",
   "editor": "Cozy",
   "categories": [
-    "online_services"
+    "clouds"
   ],
   "fields": {
     "login": {


### PR DESCRIPTION
Replace category in manifest for the konnector to display in "clouds and vaults" category in the store